### PR TITLE
Update requirements.txt to work on a Mac M1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pygame==2.1.0
-pyinstaller==4.7
+pygame==2.6.1
+pyinstaller==6.12.0


### PR DESCRIPTION
It seems as though pygame 2.1.0 would not install on my Mac M1. Instead, I installed the most recent version of these dependencies and had success.

pygame 2.6.1 was the only version of pygame that would install on my machine. pyinstaller 4.7 would install, as would the newest version, 6.12.0.

I tested noisebox on my machine after installing the latest version of both, and had success.